### PR TITLE
trigger workflow on any .pix file change

### DIFF
--- a/.github/workflows/publish_pix_data.yml
+++ b/.github/workflows/publish_pix_data.yml
@@ -7,7 +7,7 @@ on:
       - main
     paths:
       - ".github/workflows/publish_pix_data.yml"
-      - "Pictures/Pix/*.pix"
+      - "**/*.pix"
 
 name: Generate Pix List for Viewer
 


### PR DESCRIPTION
monitor whole repo for `*.pix` changes instead of just under the `Pictures\Pix` directory